### PR TITLE
Added `email` as template variable in the Forgot Password email notification

### DIFF
--- a/system/expressionengine/third_party/freemember/libraries/freemember_lib.php
+++ b/system/expressionengine/third_party/freemember/libraries/freemember_lib.php
@@ -270,6 +270,7 @@ class Freemember_lib
 
         $email_vars = array();
         $email_vars[0]['name'] = $member->username;
+        $email_vars[0]['email'] = $member->email;
         $email_vars[0]['username'] = $member->username;
         $email_vars[0]['reset_url'] = $reset_url;
         $email_vars[0]['site_name'] = ee()->config->item('site_name');


### PR DESCRIPTION
This addition is useful for EE installs where members use their email address to login instead of their username.